### PR TITLE
zip bundling + building binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Build NES Bundler
+
+on: [push]
+
+jobs:
+  build-x86_64-unknown-linux-gnu:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install latest rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Install dependencies
+        run: sudo apt install libudev-dev libasound2-dev
+
+      - name: Build
+        run: cargo build --release --target x86_64-unknown-linux-gnu && mv target/x86_64-unknown-linux-gnu/release/nes-bundler target/release/nes-bundler-x86_64-unknown-linux-gnu
+      
+      - name: Build (no Netplay)
+        run: cargo build --release --target x86_64-unknown-linux-gnu --no-default-features && mv target/x86_64-unknown-linux-gnu/release/nes-bundler target/release/nes-bundler-no-netplay-x86_64-unknown-linux-gnu
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            target/release/nes-bundler-x86_64-unknown-linux-gnu
+            target/release/nes-bundler-no-netplay-x86_64-unknown-linux-gnu
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-i686-pc-windows-msvc:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install latest rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        run: cargo build --release --target i686-pc-windows-msvc
+      
+      - name: Rename
+        run: move target/i686-pc-windows-msvc/release/nes-bundler.exe target/release/nes-bundler-i686-pc-windows-msvc.exe
+      
+      - name: Build (no Netplay)
+        run: cargo build --release --no-default-features --target i686-pc-windows-msvc
+      
+      - name: Rename (no Netplay)
+        run: move target/i686-pc-windows-msvc/release/nes-bundler.exe target/release/nes-bundler-no-netplay-i686-pc-windows-msvc.exe
+      
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            target/release/nes-bundler-i686-pc-windows-msvc.exe
+            target/release/nes-bundler-no-netplay-i686-pc-windows-msvc.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-x86_64-apple-darwin:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install latest rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        run: cargo build --release --target x86_64-apple-darwin && mv target/x86_64-apple-darwin/release/nes-bundler target/release/nes-bundler-x86_64-apple-darwin
+      
+      - name: Build (no Netplay)
+        run: cargo build --release --no-default-features --target x86_64-apple-darwin && mv target/x86_64-apple-darwin/release/nes-bundler target/release/nes-bundler-no-netplay-x86_64-apple-darwin
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            target/release/nes-bundler-x86_64-apple-darwin
+            target/release/nes-bundler-no-netplay-x86_64-apple-darwin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+  build-aarch64-apple-darwin:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install latest rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Build
+        run: cargo build --release --target aarch64-apple-darwin && mv target/aarch64-apple-darwin/release/nes-bundler target/release/nes-bundler-aarch64-apple-darwin
+      
+      - name: Build (no Netplay)
+        run: cargo build --release --no-default-features --target aarch64-apple-darwin && mv target/aarch64-apple-darwin/release/nes-bundler target/release/nes-bundler-no-netplay-aarch64-apple-darwin
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            target/release/nes-bundler-aarch64-apple-darwin
+            target/release/nes-bundler-no-netplay-aarch64-apple-darwin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1425,16 @@ checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2432,6 +2451,7 @@ dependencies = [
  "tokio",
  "uuid 1.1.2",
  "winit",
+ "zip",
 ]
 
 [[package]]
@@ -4817,4 +4837,16 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ tokio = { version = "1", features = ["rt"], optional = true }
 futures = {version = "0.3", optional = true }
 uuid = { version = "1", features = [ "v4" ], optional = true }
 reqwest = { version = "0.11", features = ["json"], optional = true }
+zip = { version = "0.6.2", default-features = false, features = ["deflate"] }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ What you get is a single executable with
 To create a bundle you need to do the following
 * [Configure a bundle](config/README.md) with your ROM and a build configuration.
 * Download the [binary of your choice](https://github.com/tedsteen/nes-bundler/releases/)
-* Run `./bundle.sh <config-dir> <downloaded-binary> <name-of-output-binary>` (`config-dir` is the directory containing your configuration)
+* Run `./bundle.sh <config-dir> <downloaded-binary> <name-of-output-binary>` (`config-dir` should contain your configuration)
 * Now there should be an executable named `<name-of-output-binary>` with your game in it!
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ What you get is a single executable with
 To create a bundle you need to do the following
 * [Configure a bundle](config/README.md) with your ROM and a build configuration.
 * Download the [binary of your choice](https://github.com/tedsteen/nes-bundler/releases/)
-* Run `./bundle.sh <config-dir> <downloaded-binary> <name-of-output-binary>` (`config-dir` should contain your configuration)
-* Now there should be an executable named `<name-of-output-binary>` with your game in it!
+* Make the bundle - `./bundle.sh <config-dir> <downloaded-binary> <name-of-output-binary>` (`config-dir` containing your configuration)
 
 ## Limitations
 
@@ -31,7 +30,6 @@ To create a bundle you need to do the following
 ## Future stuff/ideas/bugs/todo
 * Move this list to the issues feature in GitHub :)
 * Implement `save_state(...)`/`load_state(...)` for all the mappers.
-* Make it possible to bundle without using Rust compiler (somehow inject the ROM+config into the binary)
 * Fullscreen mode (alt+enter is standard to toggle between full screen and windowed, on Windows)
   * Some way to quit without closing the window will be needed for fullscreen. Probably a button in the settings menu.
 * Perhaps freeze the game while settings is open?

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Transform your NES-game into a single executable targeting your favourite OS!**
 
 Did you make a NES-game but none of your friends own a Nintendo? Don't worry.  
-Put your ROM and configuration in NES Bundler and build an executable for Mac, Windows or Linux.  
+Put your ROM and configuration in NES Bundler and build for Mac, Windows or Linux.  
 What you get is a single executable with
 * Simple UI for settings (Show and hide with ESC).
 * Re-mappable Keyboard and Gamepad input (you bundle your default mappings).
@@ -17,11 +17,10 @@ What you get is a single executable with
 ## Bundling
 
 To create a bundle you need to do the following
-* [Install Rust](https://www.rust-lang.org/tools/install).
 * [Configure a bundle](config/README.md) with your ROM and a build configuration.
-* Build `cargo build --release` your exectutable! ( use the flag `--no-default-features` to disable Netplay)
-
-If you want to target other operating systems please read the Rust documentation or find a machine with that OS and follow the steps again.
+* Download the [binary of your choice](https://github.com/tedsteen/nes-bundler/releases/)
+* Run `./bundle.sh <config-dir> <downloaded-binary> <name-of-output-binary>` (`config-dir` is the directory containing your configuration)
+* Now there should be an executable named `<name-of-output-binary>` with your game in it!
 
 ## Limitations
 

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-changed=config/build_config.yaml");
-    println!("cargo:rerun-if-changed=config/rom.nes");
-}

--- a/bundle.bat
+++ b/bundle.bat
@@ -1,0 +1,1 @@
+ECHO "TODO"

--- a/bundle.sh
+++ b/bundle.sh
@@ -10,14 +10,17 @@ function cleanup {
 }
 
 # Pack the config
-zip -jT config.zip $CONF_DIR/config.yaml $CONF_DIR/rom.nes
+zip -jT config.zip $CONF_DIR/config.yaml $CONF_DIR/rom.nes &> /dev/null
 trap cleanup EXIT
 
 # Merge with binary
 cat $NES_BUNDLER_BINARY config.zip > $NAME
 
 # Adjust self-extracting exe
-zip -A $NAME
+zip -A $NAME &> /dev/null
 
 # Make it executable
 chmod +x $NAME
+
+echo "Finished!"
+echo "./$NAME"

--- a/bundle.sh
+++ b/bundle.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Where to find the config
+CONF_DIR=${1:-config}
+# What to name the final binary
+NAME=${2:-out}
+
+# Pack the config
+zip -jT $CONF_DIR/config.zip $CONF_DIR/config.yaml $CONF_DIR/rom.nes
+# Merge with binary
+cat target/release/nes-bundler $CONF_DIR/config.zip > $NAME
+# Adjust self-extracting exe
+zip -A $NAME
+# Make it executable
+chmod +x $NAME

--- a/bundle.sh
+++ b/bundle.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 # Where to find the config
 CONF_DIR=${1:-config}
+NES_BUNDLER_BINARY=${2:-target/release/nes-bundler}
 # What to name the final binary
-NAME=${2:-out}
+NAME=${3:-out}
+
+function cleanup {
+    rm config.zip
+}
 
 # Pack the config
-zip -jT $CONF_DIR/config.zip $CONF_DIR/config.yaml $CONF_DIR/rom.nes
+zip -jT config.zip $CONF_DIR/config.yaml $CONF_DIR/rom.nes
+trap cleanup EXIT
+
 # Merge with binary
-cat target/release/nes-bundler $CONF_DIR/config.zip > $NAME
+cat $NES_BUNDLER_BINARY config.zip > $NAME
+
 # Adjust self-extracting exe
 zip -A $NAME
+
 # Make it executable
 chmod +x $NAME

--- a/config/README.md
+++ b/config/README.md
@@ -1,13 +1,13 @@
 # Configure your bundle
 
-In order to build your bundle you need two files in this directory.  
+In order to build your bundle you need two files.  
 
-* A `build_config.yaml` containing the build configuration.
+* A `config.yaml` containing the build configuration.
 * A `nes.rom` with your game.
 
 ## Build configuration
 
-A file named `build_config.yaml` looking something like this:
+A file named `config.yaml` looking something like this:
 ```yaml
 # For all the gory details see the `BuildConfiguration`-struct in the source.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,13 @@
 #![deny(clippy::all)]
 #![forbid(unsafe_code)]
 
+use std::collections::hash_map::DefaultHasher;
+use std::env;
+use std::fs::File;
+use std::hash::{Hash};
+use std::io::Read;
+use std::path::PathBuf;
+
 use crate::input::JoypadInput;
 use anyhow::Result;
 use audio::{Audio, Stream};
@@ -47,24 +54,35 @@ pub fn load_rom(cart_data: Vec<u8>) -> Result<NesState, String> {
         _err => Err("ouch".to_owned()),
     }
 }
+struct Bundle {
+    config: BuildConfiguration,
+    rom: Vec<u8>,
+}
 
-#[derive(Deserialize)]
+fn extract_bundle(self_path: &PathBuf) -> Result<Bundle> {
+    let mut zip = zip::ZipArchive::new(File::open(self_path)?)?;
+    let config: BuildConfiguration = serde_yaml::from_reader(zip.by_name("config.yaml")?)?;
+    let mut rom = Vec::new();
+    zip.by_name("rom.nes")?.read_to_end(&mut rom)?;
+    Ok(Bundle { config, rom })
+}
+
+#[derive(Deserialize, Debug)]
 pub struct BuildConfiguration {
     window_title: String,
     default_settings: Settings,
     #[cfg(feature = "netplay")]
     netplay: netplay::NetplayBuildConfiguration,
 }
-fn main() {
-    let build_config: BuildConfiguration =
-        serde_yaml::from_str(include_str!("../config/build_config.yaml")).unwrap();
-
+fn main() -> Result<()> {
+    let bundle = extract_bundle(&env::current_exe()?)
+        .map_err(|err| anyhow::Error::msg(format!("Could not extract bundle config ({err})")))?;
     #[cfg(feature = "netplay")]
     if std::env::args()
         .collect::<String>()
         .contains(&"--print-netplay-id".to_string())
     {
-        if let Some(id) = build_config.netplay.netplay_id {
+        if let Some(id) = bundle.config.netplay.netplay_id {
             println!("{id}");
         }
         std::process::exit(0);
@@ -74,7 +92,7 @@ fn main() {
 
     let window = {
         WindowBuilder::new()
-            .with_title(&build_config.window_title)
+            .with_title(&bundle.config.window_title)
             .with_inner_size(LogicalSize::new(WIDTH as f32 * ZOOM, HEIGHT as f32 * ZOOM))
             .with_min_inner_size(LogicalSize::new(WIDTH, HEIGHT))
             .build(&event_loop)
@@ -92,7 +110,7 @@ fn main() {
         (pixels, framework)
     };
 
-    let game_runner = GameRunner::new(pixels, &build_config);
+    let game_runner = GameRunner::new(pixels, &bundle.config, bundle.rom);
     let mut last_settings = game_runner.settings.get_hash();
     game_loop(
         event_loop,
@@ -137,14 +155,13 @@ fn main() {
 pub struct MyGameState {
     nes: NesState,
 }
-pub const ROM: &[u8] = include_bytes!("../config/rom.nes");
 
 impl MyGameState {
-    fn new() -> Self {
+    fn new(rom: Vec<u8>) -> Self {
         let rom_data = match std::env::var("ROM_FILE") {
             Ok(rom_file) => std::fs::read(&rom_file)
                 .unwrap_or_else(|_| panic!("Could not read ROM {}", rom_file)),
-            Err(_e) => ROM.to_vec(),
+            Err(_e) => rom.to_vec(),
         };
 
         let nes = load_rom(rom_data).expect("Failed to load ROM");
@@ -189,15 +206,19 @@ pub struct GameRunner {
     #[cfg(feature = "debug")]
     debug: debug::DebugSettings,
 }
+
 impl GameRunner {
-    pub fn new(pixels: Pixels, build_config: &BuildConfiguration) -> Self {
+    pub fn new(pixels: Pixels, build_config: &BuildConfiguration, rom: Vec<u8>) -> Self {
         let inputs = Inputs::new(build_config.default_settings.input.clone());
         #[allow(unused_mut)] // needs to be mut for netplay feature
         let mut settings: Settings = Settings::new(&build_config.default_settings);
 
+        let mut game_hash = DefaultHasher::new();
+        rom.hash(&mut game_hash);
+
         let audio = Audio::new();
         let sound_stream = audio.start(&settings.audio).expect("Could not start Audio");
-        let mut state = MyGameState::new();
+        let mut state = MyGameState::new(rom);
         state
             .nes
             .apu
@@ -208,7 +229,7 @@ impl GameRunner {
             sound_stream,
             pixels,
             #[cfg(feature = "netplay")]
-            netplay: netplay::Netplay::new(&build_config.netplay, &mut settings),
+            netplay: netplay::Netplay::new(&build_config.netplay, &mut settings, std::hash::Hasher::finish(&game_hash)),
             settings,
             inputs,
             #[cfg(feature = "debug")]


### PR DESCRIPTION
Bundle the configuration as zip and make NES Bundler a self-extractor stub.
This requires built binaries for the major target OSs so this PR includes
* switching to self extractor stub
* GitHub actions for building the binaries (win-i686, linux-x86_64, darwin-x86 (mac x86) and darwin-aarch64 (mac m1))