### PR TITLE
Properly reset NES state at netplay connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,7 +3308,7 @@ dependencies = [
 [[package]]
 name = "rusticnes-core"
 version = "0.2.0"
-source = "git+https://github.com/tedsteen/rusticnes-core-for-nes-bundler#8ce6c8b84f3a580e35357b3c7c1d7c73d51fe89b"
+source = "git+https://github.com/tedsteen/rusticnes-core-for-nes-bundler#5167ec1b101780103b1e5fda47832402b7183717"
 
 [[package]]
 name = "rustix"

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,7 +310,8 @@ impl MyGameState {
     }
     #[cfg(feature = "netplay")]
     fn reset(&mut self) {
-        self.nes.reset();
+        self.nes = NesState::new(self.nes.mapper.clone());
+        self.nes.power_on();
         self.frame = 0;
     }
 }

--- a/src/netplay/mod.rs
+++ b/src/netplay/mod.rs
@@ -382,13 +382,13 @@ impl Netplay {
                         if let Some(p2p_session) = &mut synchronizing_state.p2p_session {
                             p2p_session.poll_remote_clients();
                             if let SessionState::Running = p2p_session.current_state() {
+                                game_state.reset();
                                 new_state = Some(NetplayState::Connected(
                                     NetplaySession::new(
                                         synchronizing_state.p2p_session.take().unwrap(),
                                     ),
                                     ConnectedState::MappingInput,
                                 ));
-                                game_state.reset();
                             }
                         }
                         new_state


### PR DESCRIPTION
Using the native reset would not properly set a clean state, causing the state between clients to diverge over time. Especially if you played a local game before a netplay session.

Recreating the NesState instance instead results in identical states between clients.
