### PR TITLE
Make sure we don't block emulation when rendering is blocked by the OS

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,9 @@ manufacturer: "Darkbits"
 # NES region to use (Pal, Ntsc or Dendy)
 nes_region: Pal
 
+# There will be tearing if disabled, there might be more dropped frames if enabled
+enable_vsync: false
+
 # This will be the default settings for the game.
 # For all the gory details see the `BuildConfiguration`-struct in the source.
 default_settings:

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -16,6 +16,8 @@ pub struct BuildConfiguration {
     pub manufacturer: String,
     pub default_settings: Settings,
     pub nes_region: NesRegion,
+    #[serde(default = "Default::default")]
+    pub enable_vsync: bool,
 
     #[cfg(feature = "netplay")]
     pub netplay: crate::netplay::NetplayBuildConfiguration,

--- a/src/emulation/gui.rs
+++ b/src/emulation/gui.rs
@@ -1,35 +1,51 @@
-use super::StateHandler;
+use std::sync::{Arc, Mutex};
+
 use crate::settings::gui::GuiComponent;
+
+use super::StateHandler;
 
 #[cfg(feature = "debug")]
 struct DebugGui {
+    nes_state: Arc<Mutex<StateHandler>>,
+
     pub speed: f32,
     pub override_speed: bool,
 }
 
 pub struct EmulatorGui {
     #[cfg(feature = "netplay")]
+    nes_state: Arc<Mutex<StateHandler>>,
+
+    #[cfg(feature = "netplay")]
     pub netplay_gui: crate::netplay::gui::NetplayGui,
     #[cfg(feature = "debug")]
     debug_gui: DebugGui,
 }
 impl EmulatorGui {
-    pub fn new() -> Self {
+    #[allow(unused_variables)]
+    pub fn new(nes_state: Arc<Mutex<StateHandler>>) -> Self {
         Self {
             #[cfg(feature = "netplay")]
             netplay_gui: crate::netplay::gui::NetplayGui::new(),
             #[cfg(feature = "debug")]
             debug_gui: DebugGui {
+                nes_state: nes_state.clone(),
                 speed: 1.0,
                 override_speed: false,
             },
+
+            #[cfg(feature = "netplay")]
+            nes_state,
         }
     }
 }
 #[cfg(feature = "debug")]
 impl DebugGui {
     fn ui(&mut self, ui: &mut egui::Ui) {
-        ui.label(format!("Frame: {}", "todo"));
+        ui.label(format!(
+            "Frame: {}",
+            super::NesStateHandler::frame(std::ops::Deref::deref(&self.nes_state.lock().unwrap()))
+        ));
         ui.horizontal(|ui| {
             egui::Grid::new("debug_grid")
                 .num_columns(2)
@@ -60,14 +76,14 @@ impl GuiComponent for EmulatorGui {
         #[cfg(feature = "debug")]
         self.debug_gui.ui(ui);
 
-        // #[cfg(feature = "netplay")]
-        // self.netplay_gui.ui(ui, &mut self.nes_state);
+        #[cfg(feature = "netplay")]
+        self.netplay_gui.ui(ui, &mut self.nes_state.lock().unwrap());
     }
 
-    // #[cfg(feature = "netplay")]
-    // fn messages(&self) -> Option<Vec<String>> {
-    //     self.netplay_gui.messages(&self.nes_state)
-    // }
+    #[cfg(feature = "netplay")]
+    fn messages(&self) -> Option<Vec<String>> {
+        self.netplay_gui.messages(&self.nes_state.lock().unwrap())
+    }
 
     fn name(&self) -> Option<String> {
         if cfg!(feature = "netplay") {
@@ -80,8 +96,8 @@ impl GuiComponent for EmulatorGui {
         None
     }
 
-    // #[cfg(all(feature = "netplay", feature = "debug"))]
-    // fn prepare(&mut self) {
-    //     self.netplay_gui.prepare(&self.nes_state);
-    // }
+    #[cfg(all(feature = "netplay", feature = "debug"))]
+    fn prepare(&mut self) {
+        self.netplay_gui.prepare(&self.nes_state.lock().unwrap());
+    }
 }

--- a/src/emulation/gui.rs
+++ b/src/emulation/gui.rs
@@ -8,16 +8,14 @@ struct DebugGui {
 }
 
 pub struct EmulatorGui {
-    pub nes_state: StateHandler,
     #[cfg(feature = "netplay")]
     pub netplay_gui: crate::netplay::gui::NetplayGui,
     #[cfg(feature = "debug")]
     debug_gui: DebugGui,
 }
 impl EmulatorGui {
-    pub fn new(nes_state: StateHandler) -> Self {
+    pub fn new() -> Self {
         Self {
-            nes_state,
             #[cfg(feature = "netplay")]
             netplay_gui: crate::netplay::gui::NetplayGui::new(),
             #[cfg(feature = "debug")]
@@ -30,11 +28,8 @@ impl EmulatorGui {
 }
 #[cfg(feature = "debug")]
 impl DebugGui {
-    fn ui(&mut self, ui: &mut egui::Ui, nes_state: &StateHandler) {
-        ui.label(format!(
-            "Frame: {}",
-            super::NesStateHandler::frame(nes_state)
-        ));
+    fn ui(&mut self, ui: &mut egui::Ui) {
+        ui.label(format!("Frame: {}", "todo"));
         ui.horizontal(|ui| {
             egui::Grid::new("debug_grid")
                 .num_columns(2)
@@ -50,11 +45,7 @@ impl DebugGui {
                     }
 
                     if self.override_speed {
-                        ui.add(
-                            egui::Slider::new(&mut self.speed, 0.01..=1.0)
-                                .suffix("x")
-                                .logarithmic(true),
-                        );
+                        ui.add(egui::Slider::new(&mut self.speed, 0.005..=2.0).suffix("x"));
                         *super::Emulator::emulation_speed_mut() = self.speed;
                     }
                     ui.end_row();
@@ -67,16 +58,16 @@ impl GuiComponent for EmulatorGui {
     #[allow(unused_variables)]
     fn ui(&mut self, ui: &mut egui::Ui) {
         #[cfg(feature = "debug")]
-        self.debug_gui.ui(ui, &self.nes_state);
+        self.debug_gui.ui(ui);
 
-        #[cfg(feature = "netplay")]
-        self.netplay_gui.ui(ui, &mut self.nes_state);
+        // #[cfg(feature = "netplay")]
+        // self.netplay_gui.ui(ui, &mut self.nes_state);
     }
 
-    #[cfg(feature = "netplay")]
-    fn messages(&self) -> Option<Vec<String>> {
-        self.netplay_gui.messages(&self.nes_state)
-    }
+    // #[cfg(feature = "netplay")]
+    // fn messages(&self) -> Option<Vec<String>> {
+    //     self.netplay_gui.messages(&self.nes_state)
+    // }
 
     fn name(&self) -> Option<String> {
         if cfg!(feature = "netplay") {
@@ -89,8 +80,8 @@ impl GuiComponent for EmulatorGui {
         None
     }
 
-    #[cfg(all(feature = "netplay", feature = "debug"))]
-    fn prepare(&mut self) {
-        self.netplay_gui.prepare(&self.nes_state);
-    }
+    // #[cfg(all(feature = "netplay", feature = "debug"))]
+    // fn prepare(&mut self) {
+    //     self.netplay_gui.prepare(&self.nes_state);
+    // }
 }

--- a/src/emulation/mod.rs
+++ b/src/emulation/mod.rs
@@ -85,6 +85,7 @@ impl Emulator {
                         audio_buffer.clear();
                         let frame = frame_buffer.push_ref();
                         if frame.is_err() {
+                            //TODO: If we get in a bad sync with vsync and drop a lot of frames then perhaps we can do something to yank things in place again?
                             rate_counter.tick("Dropped frame");
                         }
                         nes_state.lock().unwrap().advance(

--- a/src/emulation/tetanes.rs
+++ b/src/emulation/tetanes.rs
@@ -104,13 +104,13 @@ impl TetanesNesState {
         }
     }
 
-    pub fn clock_frame_into(&mut self, buffers: Option<&mut NESBuffers>) -> Result<usize> {
+    pub fn clock_frame_into(&mut self, buffers: &mut NESBuffers) -> Result<usize> {
         #[cfg(feature = "debug")]
         puffin::profile_function!();
 
         self.control_deck.cpu_mut().bus.ppu.skip_rendering = false;
         let cycles = self.control_deck.clock_frame()?;
-        if let Some(buffers) = buffers {
+        if let Some(video) = &mut buffers.video {
             #[cfg(feature = "debug")]
             puffin::profile_scope!("copy buffers");
             self.control_deck
@@ -123,19 +123,19 @@ impl TetanesNesState {
                 .for_each(|(idx, &palette_index)| {
                     let palette_index = palette_index as usize * 3;
                     let pixel_index = idx * 4;
-                    buffers.video[pixel_index..pixel_index + 3]
+                    video[pixel_index..pixel_index + 3]
                         .clone_from_slice(&NTSC_PAL[palette_index..palette_index + 3]);
                 });
-            buffers
-                .audio
-                .extend_from_slice(&self.control_deck.cpu().bus.audio_samples());
+        }
+        if let Some(audio) = &mut buffers.audio {
+            audio.extend_from_slice(self.control_deck.cpu().bus.audio_samples());
         }
 
         self.control_deck.clear_audio_samples();
         Ok(cycles)
     }
 
-    pub fn clock_frame_ahead_into(&mut self, buffers: Option<&mut NESBuffers>) -> Result<usize> {
+    pub fn clock_frame_ahead_into(&mut self, buffers: &mut NESBuffers) -> Result<usize> {
         #[cfg(feature = "debug")]
         puffin::profile_function!();
 
@@ -173,11 +173,7 @@ impl TetanesNesState {
 }
 
 impl NesStateHandler for TetanesNesState {
-    fn advance(
-        &mut self,
-        joypad_state: [JoypadState; MAX_PLAYERS],
-        buffers: Option<&mut NESBuffers>,
-    ) {
+    fn advance(&mut self, joypad_state: [JoypadState; MAX_PLAYERS], buffers: &mut NESBuffers) {
         self.set_speed(*Emulator::emulation_speed());
 
         *self.control_deck.joypad_mut(Player::One) = Joypad::from_bytes((*joypad_state[0]).into());

--- a/src/emulation/tetanes.rs
+++ b/src/emulation/tetanes.rs
@@ -86,7 +86,7 @@ impl TetanesNesState {
     }
 
     fn set_speed(&mut self, speed: f32) {
-        let speed = speed.max(0.01).min(1.0);
+        let speed = speed.max(0.005);
         let apu = &mut self.control_deck.cpu_mut().bus.apu;
         let target_sample_rate = match apu.region {
             // Downsample a tiny bit extra to match the most common screen refresh rate (60hz)

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use audio::gui::AudioGui;
 use audio::Audio;
 use bundle::Bundle;
 
-use emulation::gui::EmulatorGui;
 use input::gamepad::ToGamepadEvent;
 use input::gui::InputsGui;
 use input::sdl2_impl::Sdl2Gamepads;
@@ -95,12 +94,11 @@ async fn run() -> anyhow::Result<()> {
     let mut main_view = MainView::new(renderer);
     let mut inputs_gui = InputsGui::new(inputs);
     let mut audio_gui = AudioGui::new(audio);
-    let mut emulator_gui = EmulatorGui::new();
 
     let emulator = Emulator::new()?;
     let shared_inputs = Arc::new(RwLock::new([JoypadState(0); MAX_PLAYERS]));
     let frame_buffer = BufferPool::new();
-    emulator
+    let mut emulator_gui = emulator
         .start_thread(audio_tx, shared_inputs.clone(), frame_buffer.clone())
         .await?;
 
@@ -125,7 +123,7 @@ async fn run() -> anyhow::Result<()> {
                     _ => {}
                 }
                 main_view.handle_window_event(
-                    &window_event,
+                    window_event,
                     &mut [&mut audio_gui, &mut inputs_gui, &mut emulator_gui],
                 );
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,25 @@
 #![allow(unsafe_code)]
 #![deny(clippy::all)]
 
+use audio::gui::AudioGui;
+use audio::Audio;
 use bundle::Bundle;
-use std::sync::mpsc::channel;
-use std::sync::Arc;
 
-use emulation::Emulator;
+use emulation::gui::EmulatorGui;
+use input::gamepad::ToGamepadEvent;
+use input::gui::InputsGui;
+use input::sdl2_impl::Sdl2Gamepads;
+use input::{Inputs, JoypadState};
+use main_view::MainView;
+
+use settings::gui::GuiEvent;
+use settings::{Settings, MAX_PLAYERS};
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use window::egui_winit_wgpu::Renderer;
+
+use emulation::{BufferPool, Emulator, SAMPLE_RATE};
 use integer_scaling::MINIMUM_INTEGER_SCALING_SIZE;
 
 use emulation::{NES_HEIGHT, NES_WIDTH_4_3};
@@ -57,32 +71,87 @@ async fn run() -> anyhow::Result<()> {
         Size::new(NES_WIDTH_4_3, NES_HEIGHT),
         &event_loop,
     )?);
+
+    // Needed because: https://github.com/libsdl-org/SDL/issues/5380#issuecomment-1071626081
+    sdl2::hint::set("SDL_JOYSTICK_THREAD", "1");
+    // TODO: Perhaps do this to fix this issue: https://github.com/libsdl-org/SDL/issues/7896#issuecomment-1616700934
+    //sdl2::hint::set("SDL_JOYSTICK_RAWINPUT", "0");
+
+    let sdl_context = sdl2::init().map_err(anyhow::Error::msg)?;
+    let mut sdl_event_pump = sdl_context.event_pump().map_err(anyhow::Error::msg)?;
+
+    let mut audio = Audio::new(
+        &sdl_context,
+        Duration::from_millis(Settings::current().audio.latency as u64),
+        SAMPLE_RATE as u32,
+    )?;
+
+    let inputs = Inputs::new(Sdl2Gamepads::new(
+        sdl_context.game_controller().map_err(anyhow::Error::msg)?,
+    ));
+    let audio_tx = audio.stream.start()?;
+
+    let renderer = Renderer::new(window.clone()).await?;
+    let mut main_view = MainView::new(renderer);
+    let mut inputs_gui = InputsGui::new(inputs);
+    let mut audio_gui = AudioGui::new(audio);
+    let mut emulator_gui = EmulatorGui::new();
+
     let emulator = Emulator::new()?;
+    let shared_inputs = Arc::new(RwLock::new([JoypadState(0); MAX_PLAYERS]));
+    let frame_buffer = BufferPool::new();
+    emulator
+        .start_thread(audio_tx, shared_inputs.clone(), frame_buffer.clone())
+        .await?;
 
-    let (event_tx, event_rx) = channel();
-    emulator.start_thread(window.clone(), event_rx).await?;
-
+    event_loop.set_control_flow(winit::event_loop::ControlFlow::Poll);
     event_loop.run(|winit_event, control_flow| {
-        if let Event::WindowEvent {
-            event: window_event,
-            ..
-        } = &winit_event
-        {
-            match window_event {
-                WindowEvent::CloseRequested | WindowEvent::Destroyed => {
-                    control_flow.exit();
+        let mut need_render = false;
+        match &winit_event {
+            Event::WindowEvent {
+                event: window_event,
+                ..
+            } => {
+                match window_event {
+                    WindowEvent::CloseRequested | WindowEvent::Destroyed => {
+                        control_flow.exit();
+                    }
+                    WindowEvent::RedrawRequested => {
+                        // Windows needs this to not freeze the window when resizing or moving
+                        #[cfg(windows)]
+                        window.request_redraw();
+                        need_render = true;
+                    }
+                    _ => {}
                 }
-                WindowEvent::RedrawRequested => {
-                    // Windows needs this to not freeze the window when resizing or moving
-                    #[cfg(windows)]
-                    window.request_redraw();
-                }
-                _ => {}
+                main_view.handle_window_event(
+                    &window_event,
+                    &mut [&mut audio_gui, &mut inputs_gui, &mut emulator_gui],
+                );
             }
-            event_tx
-                .send(window_event.clone())
-                .expect("to be able to send the window event");
-        };
+            Event::AboutToWait => {
+                need_render = true;
+            }
+            _ => {}
+        }
+        for sdl_gui_event in sdl_event_pump
+            .poll_iter()
+            .flat_map(|e| e.to_gamepad_event())
+            .map(GuiEvent::Gamepad)
+        {
+            main_view.handle_gui_event(
+                &sdl_gui_event,
+                &mut [&mut audio_gui, &mut inputs_gui, &mut emulator_gui],
+            );
+        }
+        *shared_inputs.write().unwrap() = inputs_gui.inputs.joypads;
+
+        if need_render {
+            main_view.render(
+                &frame_buffer,
+                &mut [&mut audio_gui, &mut inputs_gui, &mut emulator_gui],
+            );
+        }
     })?;
 
     Ok(())

--- a/src/netplay/gui.rs
+++ b/src/netplay/gui.rs
@@ -168,7 +168,7 @@ impl NetplayGui {
                         do_join = join_btn_clicked || enter_pressed_in_room_input;
 
                         ui.end_row();
-                        ui.label("or simply");
+                        ui.label("or");
                         random_clicked = ui.button("Match with a random player").clicked();
                         ui.end_row();
                     });

--- a/src/netplay/mod.rs
+++ b/src/netplay/mod.rs
@@ -92,11 +92,7 @@ impl DerefMut for NetplayNesState {
 }
 
 impl NesStateHandler for NetplayStateHandler {
-    fn advance(
-        &mut self,
-        joypad_state: [JoypadState; MAX_PLAYERS],
-        buffers: Option<&mut NESBuffers>,
-    ) {
+    fn advance(&mut self, joypad_state: [JoypadState; MAX_PLAYERS], buffers: &mut NESBuffers) {
         if let Some(new_state) = self
             .netplay
             .take()

--- a/src/window/egui_winit_wgpu/mod.rs
+++ b/src/window/egui_winit_wgpu/mod.rs
@@ -9,6 +9,8 @@ use gui::EguiRenderer;
 use wgpu::{PresentMode, TextureViewDescriptor};
 use winit::window::Window;
 
+use crate::bundle::Bundle;
+
 pub mod texture;
 
 pub struct Renderer {
@@ -63,14 +65,18 @@ impl Renderer {
             .find(|f| !f.is_srgb())
             .unwrap_or(surface_caps.formats[0]);
 
-        let best_mode = [
-            PresentMode::Mailbox,
-            PresentMode::Immediate,
-            PresentMode::Fifo,
-        ]
-        .into_iter()
-        .find(|mode| surface_caps.present_modes.contains(mode))
-        .unwrap_or(PresentMode::AutoNoVsync);
+        let present_mode = if Bundle::current().config.enable_vsync {
+            PresentMode::AutoVsync
+        } else {
+            [
+                PresentMode::Mailbox,
+                PresentMode::Immediate,
+                PresentMode::Fifo,
+            ]
+            .into_iter()
+            .find(|mode| surface_caps.present_modes.contains(mode))
+            .unwrap_or(PresentMode::AutoNoVsync)
+        };
 
         let config = wgpu::SurfaceConfiguration {
             desired_maximum_frame_latency: 1,
@@ -78,7 +84,7 @@ impl Renderer {
             format: surface_format,
             width: size.width,
             height: size.height,
-            present_mode: best_mode,
+            present_mode,
             alpha_mode: surface_caps.alpha_modes[0],
             view_formats: vec![],
         };

--- a/src/window/egui_winit_wgpu/mod.rs
+++ b/src/window/egui_winit_wgpu/mod.rs
@@ -63,13 +63,22 @@ impl Renderer {
             .find(|f| !f.is_srgb())
             .unwrap_or(surface_caps.formats[0]);
 
+        let best_mode = [
+            PresentMode::Mailbox,
+            PresentMode::Immediate,
+            PresentMode::Fifo,
+        ]
+        .into_iter()
+        .find(|mode| surface_caps.present_modes.contains(mode))
+        .unwrap_or(PresentMode::AutoNoVsync);
+
         let config = wgpu::SurfaceConfiguration {
             desired_maximum_frame_latency: 1,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: surface_format,
             width: size.width,
             height: size.height,
-            present_mode: PresentMode::AutoVsync,
+            present_mode: best_mode,
             alpha_mode: surface_caps.alpha_modes[0],
             view_formats: vec![],
         };
@@ -153,9 +162,6 @@ impl Renderer {
             #[cfg(feature = "debug")]
             puffin::profile_scope!("egui.draw");
 
-            //TODO: Using a window here (and above) blocks on macos when minimizing/maximizing or occluding the window.
-            //      All the `maybe_wait_on_main` calls inside the window will block.
-            //      Figure out if we can somehow remove the dependency on the window here...
             self.egui.draw(
                 &self.device,
                 &self.queue,


### PR DESCRIPTION
The OS will block access to the window object during certain circumstances and we need to keep the emulation going.
The solution was to move the emulation to a separate thread and do rendering on the main thread.
