### PR TITLE
Fix ESC mapping bug

### DIFF
--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -15,10 +15,11 @@ impl Keyboards {
     }
     pub fn advance(&mut self, key_event: &KeyEvent) {
         match key_event {
-            KeyEvent::Pressed(key) => {
+            // NOTE: Ignore the escape key as it is used for main menu navigation
+            KeyEvent::Pressed(key) if *key != KeyCode::Escape => {
                 self.pressed_keys.insert(*key);
             }
-            KeyEvent::Released(key) => {
+            KeyEvent::Released(key) if *key != KeyCode::Escape => {
                 self.pressed_keys.remove(key);
             }
             _ => (),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -257,12 +257,8 @@ impl Inputs {
                 match &mut input_configuration.kind {
                     InputConfigurationKind::Keyboard(mapping) => {
                         if let Some(code) = self.keyboards.pressed_keys.iter().next() {
-                            // Don't map ESC as it is used for menu navigation
-                            if !matches!(code, KeyCode::Escape) {
-                                //If there's any key pressed, use the first found.
-                                let _ = mapping.lookup(button).insert(*code);
-                                remapped = true;
-                            }
+                            let _ = mapping.lookup(button).insert(*code);
+                            remapped = true;
                         }
                     }
                     InputConfigurationKind::Gamepad(mapping) => {
@@ -271,7 +267,7 @@ impl Inputs {
                             gamepads.get_gamepad_by_input_id(&input_configuration_id)
                         {
                             if let Some(new_button) = state.get_pressed_buttons().iter().next() {
-                                //If there's any button pressed, use the first found... unless it's the reserved "Guide" button
+                                //If there's any button pressed, use the first found... unless it's the reserved "Guide" button used for bringing up the main menu
                                 if !matches!(new_button, GamepadButton::Guide) {
                                     let _ = mapping.lookup(button).insert(*new_button);
                                     remapped = true;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -257,9 +257,12 @@ impl Inputs {
                 match &mut input_configuration.kind {
                     InputConfigurationKind::Keyboard(mapping) => {
                         if let Some(code) = self.keyboards.pressed_keys.iter().next() {
-                            //If there's any key pressed, use the first found.
-                            let _ = mapping.lookup(button).insert(*code);
-                            remapped = true;
+                            // Don't map ESC as it is used for menu navigation
+                            if !matches!(code, KeyCode::Escape) {
+                                //If there's any key pressed, use the first found.
+                                let _ = mapping.lookup(button).insert(*code);
+                                remapped = true;
+                            }
                         }
                     }
                     InputConfigurationKind::Gamepad(mapping) => {


### PR DESCRIPTION
Escape was messing with the keyboard re-mapping.
Removed escape as an option to map since it doesn't make sense anyway to map anything to the same button that brings up the main menu.
