### PR TITLE
Fix netplay resume

### DIFF
--- a/src/netplay/connecting_state.rs
+++ b/src/netplay/connecting_state.rs
@@ -164,16 +164,18 @@ impl PeeringState {
     ) -> Self {
         let matchbox_server = &netplay_server_configuration.matchbox.server;
 
+        //TODO: matchbox will panic when we advance the frame on the ggrs session if we do not pass `players=2` here. See discussion (https://discord.com/channels/844211600009199626/1045611882691698688/1325596000928399495) for details.
+        //      revert this when the bug is fixed in matchbox.
         let room_name = match &start_method {
             StartMethod::Start(StartState { session_id, .. }, ..) => {
-                format!("join_{}", session_id)
+                format!("join_{}?next=2", session_id)
             }
             StartMethod::Resume(StartState {
                 session_id,
                 game_state,
                 ..
             }) => {
-                format!("resume_{}_{}", session_id, game_state.frame)
+                format!("resume_{}_{}?next=2", session_id, game_state.frame)
             }
             StartMethod::MatchWithRandom(StartState { session_id, .. }) => {
                 format!("random_{}?next=2", session_id)
@@ -207,6 +209,7 @@ impl PeeringState {
 
         let loop_fut = loop_fut.fuse();
         let timeout = Delay::new(Duration::from_millis(100));
+
         tokio::spawn(async move {
             futures::pin_mut!(loop_fut, timeout);
             loop {

--- a/src/netplay/netplay_session.rs
+++ b/src/netplay/netplay_session.rs
@@ -125,7 +125,7 @@ impl NetplaySessionState {
                             if !is_replay {
                                 //This is not a replay
                                 self.last_handled_frame = self.game_state.frame;
-                                if self.game_state.frame % (sess.max_prediction() * 2) as i32 == 0 {
+                                if self.game_state.frame % (sess.max_prediction() + 1) as i32 == 0 {
                                     mem::swap(
                                         &mut self.last_confirmed_game_state1,
                                         &mut self.last_confirmed_game_state2,

--- a/src/netplay/netplay_state.rs
+++ b/src/netplay/netplay_state.rs
@@ -94,13 +94,13 @@ impl ResumingState {
 
         let session_id = netplay.state.session_id.clone();
         Self {
-            attempt1: ConnectingState::resume(
-                netplay_session.last_confirmed_game_state1.clone(),
+            attempt2: ConnectingState::resume(
+                netplay_session.last_confirmed_game_state2.clone(),
                 session_id.clone(),
                 netplay_session.netplay_server_configuration.clone(),
             ),
-            attempt2: ConnectingState::resume(
-                netplay_session.last_confirmed_game_state2.clone(),
+            attempt1: ConnectingState::resume(
+                netplay_session.last_confirmed_game_state1.clone(),
                 session_id.clone(),
                 netplay_session.netplay_server_configuration.clone(),
             ),
@@ -266,16 +266,16 @@ impl Netplay<ConnectedState> {
 impl Netplay<ResumingState> {
     fn advance(mut self) -> NetplayState {
         //log::trace!("Advancing Netplay<Resuming>");
-        self.state.attempt1 = self.state.attempt1.advance();
         self.state.attempt2 = self.state.attempt2.advance();
+        self.state.attempt1 = self.state.attempt1.advance();
 
-        if let ConnectingState::Connected(_) = &self.state.attempt1 {
-            NetplayState::Connecting(Netplay {
-                state: self.state.attempt1,
-            })
-        } else if let ConnectingState::Connected(_) = &self.state.attempt2 {
+        if let ConnectingState::Connected(_) = &self.state.attempt2 {
             NetplayState::Connecting(Netplay {
                 state: self.state.attempt2,
+            })
+        } else if let ConnectingState::Connected(_) = &self.state.attempt1 {
+            NetplayState::Connecting(Netplay {
+                state: self.state.attempt1,
             })
         } else {
             NetplayState::Resuming(self)


### PR DESCRIPTION
A panic in matchbox was avoided using this "hack". When/if this is fixed in matchbox this should be reverted.